### PR TITLE
Fix premature loop-back on palette

### DIFF
--- a/obj-viewer.py
+++ b/obj-viewer.py
@@ -866,7 +866,7 @@ class MainFrame(tk.Frame):
         self.cgram_label = ttk.Label(self.frame_frame_controls, text="CGRAM Offset")
         self.cgram_label.grid(row=i, column=0, padx=3, pady=3, sticky=tk.W)
         self.cgram_num = ttk.Spinbox(self.frame_frame_controls,
-                                     from_=0, to=128,
+                                     from_=0, to=256,
                                      increment=16,
                                      width=8,
                                      wrap=1,


### PR DESCRIPTION
Palettes are a total of 256 colors (16 palettes). This can be seen in the palette preview. The current CGRAM offset prematurely loops back to color 0 (palette 0) when it reaches the 128th color (8th palette). This change will let the CGRAM offset access the full palette.